### PR TITLE
check_pagespeed: optionally supply google API key as second argument

### DIFF
--- a/check_pagespeed
+++ b/check_pagespeed
@@ -9,7 +9,12 @@
 # https://code.google.com/apis/pagespeedonline/v1/reference.html
 
 $targeturl = $argv[1];
-$apikey = $argv[2];
+
+if ( isset($argv[2]) && !empty($argv[2]) ) {
+    $apikey = $argv[2];
+} else {
+    $apikey = 'XXX PUT GOOGLE API KEY HERE XXX';
+}
 
 $url='https://www.googleapis.com/pagespeedonline/v1/runPagespeed?key='.$apikey.'&url='.$targeturl;
 $json = json_decode(`wget -q -O - "$url"`);


### PR DESCRIPTION
Since i would like to keep your fabulous nagios plugins up to date, i think it's better to supply the google API key as an CLI argument instead of modifying the check script.
Plus, one can now use different google accounts e.g. for different customers.
