### PR TITLE
changing time format of check_awsiops

### DIFF
--- a/check_awsiops
+++ b/check_awsiops
@@ -19,8 +19,8 @@ define('AWS_SECRET_KEY', $options["S"]);
 error_reporting(-1);
 
 date_default_timezone_set('America/Denver');
-$time_interval = date('o-m-d H:i:s', strtotime("10 minutes ago"));
-$now           = date('o-m-d H:i:s',time());
+$time_interval = strtotime("10 minutes ago");
+$now           = strtotime("now");
 
 
 require 'aws.phar';


### PR DESCRIPTION
even though the API docs say time format is fine as a string in date/time format (http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.CloudWatch.CloudWatchClient.html#_getMetricStatistics), it's not working. This PR changes the format to a timestamp instead.

Sample output running modified version:
AWS IOPS OKAY; | VolumeReadBytes=1400832.0;;;VolumeWriteBytes=3416064.0;;;VolumeReadOps=121.0;;;VolumeWriteOps=281.0
