### PR TITLE
Fix performance data ouptut

### DIFF
--- a/check_graylog2_server
+++ b/check_graylog2_server
@@ -44,7 +44,7 @@ def main():
     print "CRITICAL error querying Graylog2 for system/throughput: %s" % e
     exit(2)
 
-  print "OK Graylog2 server is healthy: %d events/sec|total_events=%d,inputs=%d,throughput=%d" % ( throughput, total_events, total_inputs, throughput )
+  print "OK Graylog2 server is healthy: %d events/sec|total_events=%d inputs=%d throughput=%d" % ( throughput, total_events, total_inputs, throughput )
   exit(0)
 
 if __name__ == "__main__":


### PR DESCRIPTION
According to the nagios plugins developer guidelines perfromance data have to be a  "space separated list of label/value pairs" (see https://nagios-plugins.org/doc/guidelines.html#AEN200).

Greetings, Michael